### PR TITLE
Debug telegram bot updater attribute error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 ## 🛠️ טכנולוגיות
 
 - Python 3.11+
-- python-telegram-bot 20.7
+- python-telegram-bot 22.5 (תואם ל-Python 3.13)
 - difflib (מובנה ב-Python)
 - Render.com (הוסטינג)
 
@@ -96,6 +96,7 @@ def hello():
 ### שגיאות בהתקנה
 - ודא שקובץ requirements.txt קיים
 - ודא ש-Python version הוא 3.11 או חדש יותר
+- אם מופיעה שגיאת `AttributeError: 'Updater' object has no attribute '_Updater__polling_cleanup_cb'`, ודא שהתקנת את התלויות מחדש (`pip install -r requirements.txt`). הגרסה המעודכנת של python-telegram-bot פותרת את הבעיה ב-Python 3.13.
 
 ## 📝 הערות
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-telegram-bot==20.7
+python-telegram-bot==22.5


### PR DESCRIPTION
Upgrade `python-telegram-bot` to version 22.5 to fix `AttributeError` on Python 3.13.

The `AttributeError: 'Updater' object has no attribute '_Updater__polling_cleanup_cb'` occurred because older versions of `python-telegram-bot` were not fully compatible with Python 3.13. Version 22.5 is the first series officially tested against Python 3.13 and resolves this compatibility issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ac2552b-8b2f-4ac3-a99c-f92fd3991600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ac2552b-8b2f-4ac3-a99c-f92fd3991600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

