### PR TITLE
Simulate port for bot testing

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,5 +1,5 @@
 services:
-  - type: web
+  - type: worker
     name: diff-visualizer-bot
     env: python
     buildCommand: pip install -r requirements.txt


### PR DESCRIPTION
Change Render service type to `worker` to resolve "No open ports detected" errors during deployment.

The bot uses long polling and does not open a port, which caused Render to terminate deployment when configured as a `web` service. Changing the service type to `worker` allows Render to run the process without expecting an open port.

---
<a href="https://cursor.com/background-agent?bcId=bc-807c0e4e-b436-4c71-9679-be28e5afcbf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-807c0e4e-b436-4c71-9679-be28e5afcbf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

