### PR TITLE
Bot stuck generating diff

### DIFF
--- a/diff_bot.py
+++ b/diff_bot.py
@@ -7,6 +7,7 @@ Shows beautiful colored diffs like Git
 import os
 import logging
 import difflib
+from html import escape
 from io import BytesIO
 from typing import Optional, Tuple
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
@@ -275,8 +276,22 @@ async def receive_second_code(update: Update, context: ContextTypes.DEFAULT_TYPE
         session['second_code']
     )
     
-    # Send text preview
-    preview_message = f"<b>🔍 תצוגת Diff מקדימה</b>\n\n<pre>{text_diff[:4000]}</pre>"
+    # Prepare safe preview text for Telegram (HTML)
+    preview_limit = 2500
+    is_truncated = len(text_diff) > preview_limit
+    preview_text = text_diff[:preview_limit]
+    escaped_preview = escape(preview_text)
+    
+    preview_message = (
+        "<b>🔍 תצוגת Diff מקדימה</b>\n\n"
+        f"<pre>{escaped_preview}</pre>"
+    )
+    
+    if is_truncated:
+        preview_message += (
+            "\n⚠️ התצוגה קוצרה עבור טלגרם. "
+            "לקבלת כל ההבדלים לחץ על קובץ ה-HTML."
+        )
     
     keyboard = [
         [InlineKeyboardButton("📄 קבל קובץ HTML מלא", callback_data='get_html_diff')],


### PR DESCRIPTION
Fixes bot getting stuck when generating diffs by escaping HTML characters and truncating long diffs for Telegram.

The bot was failing to send diffs containing special HTML characters or very long diffs to Telegram due to unescaped HTML and length limits, causing it to appear stuck.

---
<a href="https://cursor.com/background-agent?bcId=bc-ced3d026-8e4d-4938-8543-ebffb07fe5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ced3d026-8e4d-4938-8543-ebffb07fe5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

