### PR TITLE
Debug reporter activity integration

### DIFF
--- a/activity_reporter.py
+++ b/activity_reporter.py
@@ -34,8 +34,8 @@ def get_mongo_client(mongodb_uri: str):
             _client = existing
             globals()["_owns_client"] = False
         else:
-            # יצירת לקוח משלנו עם timezone-aware
-            _client = MongoClient(mongodb_uri, tz_aware=True, tzinfo=timezone.utc)
+            # יצירת לקוח משלנו עם timezone-aware (Mongo כבר מחזיר UTC)
+            _client = MongoClient(mongodb_uri, tz_aware=True)
             globals()["_owns_client"] = True
     return _client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-telegram-bot==21.0.1
 python-dotenv==1.0.0
+pymongo[srv]==4.6.3


### PR DESCRIPTION
Fixes `TypeError` in `MongoClient` initialization and adds `pymongo[srv]` to `requirements.txt`.

The `MongoClient` was failing due to an unrecognized `tzinfo` parameter, and the `pymongo[srv]` library was missing from the dependencies, preventing the activity reporter from running.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e8b9fd9-695d-40fc-b44a-8ec8de63ad04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e8b9fd9-695d-40fc-b44a-8ec8de63ad04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

